### PR TITLE
Feature/deploy user group

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Role Variables
 |------------------------------|----------------------------------------------------------|----------------|
 | deploy_user_username         | Username of the deployment user                          | `ansible`      |
 | deploy_user_comment          | Comment for the deployment user                          | `Ansible User` |
+| deploy_user_groupname        | Name of the deployment user group                        | `ansible`      |
 | deploy_user_ssh_keys_present | A list of SSH keys to be present for the deployment user | `[]`           |
 | deploy_user_ssh_keys_absent  | A list of SSH keys to be absent for the deployment user  | `[]`           |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,6 @@
 # defaults file for deploy_user
 deploy_user_username: ansible
 deploy_user_comment: Ansible User
+deploy_user_groupname: ansible
 deploy_user_ssh_keys_present: []
 deploy_user_ssh_keys_absent: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,10 +6,18 @@
   become: true
   become_user: root
 
+- name: Ensure deploy user group exists
+  ansible.builtin.group:
+    name: "{{ deploy_user_groupname }}"
+    state: present
+  become: true
+  become_user: root
+
 - name: Ensure deploy user exists
   ansible.builtin.user:
     name: "{{ deploy_user_username }}"
     comment: "{{ deploy_user_comment }}"
+    group: "{{ deploy_user_groupname }}"
     create_home: true
     password: "!"
   become: true
@@ -29,8 +37,8 @@
     path: "{{ deploy_user_home }}"
     state: directory
     owner: "{{ deploy_user_username }}"
-    group: "{{ deploy_user_username }}"
-    mode: '0700'
+    group: "{{ deploy_user_groupname }}"
+    mode: '0750'
   become: true
   become_user: root
 


### PR DESCRIPTION
Make the deploy user group configurable and ensure creation. This is required for OSes which do not automatically create a user group with the name of a newly created user like SLES or RHEL.