### PR TITLE
refactor: use ansible_fact namespace

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Set home directory var for deploy user
   ansible.builtin.set_fact:
-    deploy_user_home: "{{ getent_passwd[deploy_user_username][4] }}"
+    deploy_user_home: "{{ ansible_facts.getent_passwd[deploy_user_username][4] }}"
   ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure secure home dir permissions


### PR DESCRIPTION
I'm currently receiving a deprecation warning when running the role. Apparently, the recommended way is to use the ansible_facts namespace to query those facts. This is supported since Ansible 2.5: https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_2.5.html#ansible-fact-namespacing

```
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /home/fuj/.ansible/collections/ansible_collections/oxivanisher/linux_base/roles/deploy_user/tasks/main.yml:37:23

35 - name: Set home directory var for deploy user
36   ansible.builtin.set_fact:
37     deploy_user_home: "{{ getent_passwd[deploy_user_username][4] }}"
                         ^ column 23

Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```